### PR TITLE
Improve the 404 experience

### DIFF
--- a/themes/citadel/layouts/404.html
+++ b/themes/citadel/layouts/404.html
@@ -6,13 +6,36 @@
 		<article class="markdown-body col-md-10 col-lg-7 mx-auto">
 			<h1>Ooops!</h1>
 			<div class="lead-mktg mb-5">It looks like this page doesn't exist (yet!).</div>
-			<a href="{{ .Site.BaseURL }}" class="pl-4 pr-2 py-2 f6 text-uppercase d-block flex-auto mr-3">Return home</a>
 
+			<div class="col-lg-12 mt-6">
+				<h3 class="mb-3">Tried the archive?</h3>
+				<div class="mb-5">You can see if this page exists using the archive URL <a id="archive-url" href="https://archive.azurecitadel.com">https://archive.azurecitadel.com</a></a></div>
 
-			<a href="https://github.com/azurecitadel/azurecitadel/discussions/" class="pl-4 pr-2 py-2 f6 text-uppercase d-block flex-auto mr-3">Start a discussion</a>
-			
+				<div>
+					<p>Otherwise you can always
+					<ul>
+						<li><a href="{{ .Site.BaseURL }}"
+								class="pl-4 pr-2 py-2 f6 text-uppercase d-block flex-auto mr-3">Return home</a></li>
+						<li> <a href="https://github.com/azurecitadel/azurecitadel/discussions/"
+								class="pl-4 pr-2 py-2 f6 text-uppercase d-block flex-auto mr-3">Start a discussion</a>
+						</li>
+					</ul>
+				</div>
+			</div>
+
 		</article>
 	</div>
 </section>
 
+{{ end }}
+
+{{ define "embedded-script" }}
+<script type="application/javascript">
+document.addEventListener('DOMContentLoaded', function(event) {
+	const link = document.getElementById("archive-url");
+	const archiveURL = "https://archive.azurecitadel.com" + window.location.pathname;
+	link.href = archiveURL;
+	link.innerText = archiveURL;
+});
+</script>
 {{ end }}

--- a/themes/citadel/layouts/_default/baseof.html
+++ b/themes/citadel/layouts/_default/baseof.html
@@ -17,4 +17,5 @@
     {{- partial "footer.html" . -}}
 </body>
 
+{{- block "embedded-script" . }}{{- end }}
 </html>

--- a/themes/citadel/layouts/partials/sidebar.html
+++ b/themes/citadel/layouts/partials/sidebar.html
@@ -12,7 +12,7 @@
     </div>
 
     <ul class="sidebar-products">
-        <ul class="sidebar-categories list-style-none">
+        <li><ul class="sidebar-categories list-style-none">
 
             {{ $currentPage := . }}
             {{ range .Site.Menus.side }}
@@ -59,6 +59,6 @@
             </li>
             {{ end }}
         </ul>
-    </ul>
+    </ul></li>
 
 </div>


### PR DESCRIPTION
We see a lot of requests for content hitting the old page URL structure and the new 404 page is very generic.

This introduces a direct link to the archive to give people a better shot at finding the content they were looking for.

Since this is a static website we use Javascript to link to the direct URL in the archive using the current browser path