### PR TITLE
Front Matter aliases for transferred content

### DIFF
--- a/content/cli/_index.md
+++ b/content/cli/_index.md
@@ -6,6 +6,8 @@ github: [ "richeney" ]
 menu:
   side:
     identifier: cli
+aliases:
+    - /prereqs/cli/
 ---
 
 ## Introduction

--- a/content/cli/install.md
+++ b/content/cli/install.md
@@ -9,6 +9,8 @@ series:
 menu:
   side:
     parent: cli
+aliases:
+    - /prereqs/cli/cli-1-setup/
 ---
 
 ## Cloud Shell

--- a/content/cli/jmespath.md
+++ b/content/cli/jmespath.md
@@ -9,6 +9,8 @@ series:
 menu:
   side:
     parent: cli
+aliases:
+    - /prereqs/cli/cli-3-jmespath/
 ---
 
 ## Introduction

--- a/content/cli/scripting.md
+++ b/content/cli/scripting.md
@@ -9,6 +9,8 @@ series:
 menu:
   side:
     parent: cli
+aliases:
+    - /prereqs/cli/cli-4-bash/
 ---
 
 ## Introduction

--- a/content/cli/using.md
+++ b/content/cli/using.md
@@ -9,6 +9,8 @@ series:
 menu:
   side:
     parent: cli
+aliases:
+    - /prereqs/cli/cli-2-firststeps/
 ---
 
 ## Logging into Azure

--- a/content/network/concepts/_index.md
+++ b/content/network/concepts/_index.md
@@ -7,6 +7,8 @@ menu:
   side:
     identifier: network-concepts
     parent: network
+aliases:
+    - /infra/networking/
 ---
 
 ## Introduction

--- a/content/network/vdc/_index.md
+++ b/content/network/vdc/_index.md
@@ -8,6 +8,8 @@ menu:
     identifier: network-vdc
     parent: network
 weight: 2
+aliases:
+    - /infra/vdc/
 ---
 
 ## Introduction

--- a/content/network/vdc/configure.md
+++ b/content/network/vdc/configure.md
@@ -9,6 +9,8 @@ series:
 menu:
   side:
     parent: network-vdc
+aliases:
+    - /infra/vdc/lab2/
 ---
 
 ## Introduction

--- a/content/network/vdc/explore.md
+++ b/content/network/vdc/explore.md
@@ -9,6 +9,8 @@ series:
 menu:
   side:
     parent: network-vdc
+aliases:
+    - /infra/vdc/lab1/
 ---
 
 ## Introduction

--- a/content/network/vdc/monitor.md
+++ b/content/network/vdc/monitor.md
@@ -9,6 +9,8 @@ series:
 menu:
   side:
     parent: network-vdc
+aliases:
+    - /infra/vdc/lab4/
 ---
 
 ## Introduction

--- a/content/network/vdc/rbac.md
+++ b/content/network/vdc/rbac.md
@@ -9,6 +9,8 @@ series:
 menu:
   side:
     parent: network-vdc
+aliases:
+    - /infra/vdc/lab5/
 ---
 
 ## Introduction

--- a/content/network/vdc/secure.md
+++ b/content/network/vdc/secure.md
@@ -9,6 +9,8 @@ series:
 menu:
   side:
     parent: network-vdc
+aliases:
+    - /infra/vdc/lab3/
 ---
 
 ## Introduction

--- a/content/network/vdc/setup.md
+++ b/content/network/vdc/setup.md
@@ -9,6 +9,8 @@ series:
 menu:
   side:
     parent: network-vdc
+aliases:
+    - /infra/vdc/lab0/
 ---
 
 ## Introduction

--- a/content/packeransible/_index.md
+++ b/content/packeransible/_index.md
@@ -6,6 +6,8 @@ github: [ "richeney" ]
 menu:
   side:
     identifier: packeransible
+aliases:
+    - /automation/packeransible/
 ---
 
 ## Introduction

--- a/content/packeransible/ansible.md
+++ b/content/packeransible/ansible.md
@@ -8,6 +8,8 @@ series:
 menu:
   side:
     parent: packeransible
+aliases:
+    - /automation/packeransible/lab2/
 ---
 
 ## Introduction

--- a/content/packeransible/custom.md
+++ b/content/packeransible/custom.md
@@ -8,6 +8,8 @@ series:
 menu:
   side:
     parent: packeransible
+aliases:
+    - /automation/packeransible/lab5/
 ---
 
 ## Introduction

--- a/content/packeransible/dynamic.md
+++ b/content/packeransible/dynamic.md
@@ -8,6 +8,8 @@ series:
 menu:
   side:
     parent: packeransible
+aliases:
+    - /automation/packeransible/lab3/
 ---
 
 ## Introduction

--- a/content/packeransible/gallery.md
+++ b/content/packeransible/gallery.md
@@ -8,6 +8,8 @@ series:
 menu:
   side:
     parent: packeransible
+aliases:
+    - /automation/packeransible/lab6/
 ---
 
 ## Introduction

--- a/content/packeransible/packer.md
+++ b/content/packeransible/packer.md
@@ -8,6 +8,8 @@ series:
 menu:
   side:
     parent: packeransible
+aliases:
+    - /automation/packeransible/lab1/
 ---
 
 ## Introduction

--- a/content/packeransible/playbooks.md
+++ b/content/packeransible/playbooks.md
@@ -8,6 +8,8 @@ series:
 menu:
   side:
     parent: packeransible
+aliases:
+    - /automation/packeransible/lab4/
 ---
 
 ## Introduction

--- a/content/policy/_index.md
+++ b/content/policy/_index.md
@@ -4,6 +4,8 @@ description: "Governance Labs for Azure Policy"
 menu:
   side:
     identifier: policy
+aliases:
+    - /automation/policy/
 ---
 
 ## Introduction

--- a/content/policy/basics/cli.md
+++ b/content/policy/basics/cli.md
@@ -9,6 +9,8 @@ series:
 menu:
   side:
     parent: policy-basics
+aliases:
+    - /automation/policy/cli/
 ---
 
 ## Introduction

--- a/content/policy/basics/dine.md
+++ b/content/policy/basics/dine.md
@@ -9,6 +9,8 @@ series:
 menu:
   side:
     parent: policy-basics
+aliases:
+    - /automation/policy/deploy/
 ---
 
 ## Introduction

--- a/content/policy/basics/mg.md
+++ b/content/policy/basics/mg.md
@@ -9,6 +9,8 @@ series:
 menu:
   side:
     parent: policy-basics
+aliases:
+    - /automation/policy/mg/
 ---
 
 ## Introduction

--- a/content/policy/basics/portal.md
+++ b/content/policy/basics/portal.md
@@ -9,6 +9,8 @@ series:
 menu:
   side:
     parent: policy-basics
+aliases:
+    - /automation/policy/basics/
 ---
 
 ## Introduction

--- a/content/policy/custom/_index.md
+++ b/content/policy/custom/_index.md
@@ -7,6 +7,9 @@ menu:
   side:
     identifier: 'policy-custom'
     parent: 'policy'
+aliases:
+    - aliases:
+    - /automation/policy/custom/
 ---
 
 ## Introduction


### PR DESCRIPTION
What it says on the tin. A bunch of aliases from the old url structure so reduce the number of 404s