### PR TITLE
Add step to install dependencies

### DIFF
--- a/content/about/contributing/github-codespaces.md
+++ b/content/about/contributing/github-codespaces.md
@@ -29,6 +29,6 @@ To start a GitHub Codespace:
 
 This will launch an online, cloud-backed instance of Visual Studio Code in your browser.
 
-You can open a terminal and run `hugo serve` as if you were running locally.
+You can open a terminal and run `hugo serve` as if you were running locally. You may need to install dependencies with `npm install`.
 
 You can [learn more about Codespaces](https://github.com/features/codespaces) from the official documentation.

--- a/content/about/contributing/remote-container.md
+++ b/content/about/contributing/remote-container.md
@@ -44,9 +44,17 @@ Use the Remote Container extension to open this project in VS Code, as shown in 
 
 {{< youtube id="g6UACfsHKKM" autoplay="false">}}
 
+### Install Dependencies
+
+Open a new terminal window in VS Code and run the following command to install dependencies
+
+```bash
+npm install
+```
+
 ### Serve content
 
-Open a new terminal window in VS Code and tell Static Web Apps to start serving the local content
+In the terminal window, tell Static Web Apps to start serving the local content
 
 ```bash
 swa start http://localhost:1313 --run "hugo server"


### PR DESCRIPTION
Following the steps in the contributing section for devcontainer / codespaces results in error messages when you try to run / serve. I had to do an `npm install` before trying to run / debug.