### PR TITLE
Post debug task to stop hugo

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,7 @@
             "cwd": "${workspaceFolder}",
             "command": "swa start ./public",
             "preLaunchTask": "hugo watch",
+            "postDebugTask": "kill hugo",
             "serverReadyAction": {
                 "pattern": "Azure Static Web Apps emulator started at http://localhost:([0-9]+)",
                 "uriFormat": "http://localhost:%s",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -70,6 +70,21 @@
 			],
 			"dependsOn": "install dependencies",
 			"label": "hugo watch"
+		},
+		{
+			"label": "kill hugo",
+			"type": "shell",
+			"command": "kill",
+			"args": [
+				{
+					"value": "$(ps -ef | grep -e ' hugo -w$' | tr -s ' ' | cut -d ' ' -f2)",
+					"quoting": "weak"
+				}
+			],
+			"presentation": {
+				"echo": false,
+				"reveal": "silent"
+			}
 		}
 	]
 }


### PR DESCRIPTION
When you stop debugging, the Hugo watch process isn't terminated. This can cause problems when starting a new debug session.

There may be a cleaner way of doing this. I've added a postDebug task which 
* Tries to extract the id for the Hugo watch process - `ps -ef | grep -e ' hugo -w$'`
* Calls kill on that process id