### PR TITLE
Update baseURL to fix codespaces issue

### DIFF
--- a/config/development/config.toml
+++ b/config/development/config.toml
@@ -1,1 +1,1 @@
-baseURL = "http://localhost:4280/"
+baseURL = ""


### PR DESCRIPTION
Setting the baseURL to "" seems to fix the issue for codespaces and local development.